### PR TITLE
Fix more PHP 8.1 deprecations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-    pull_request: ~
+    pull_request:
     push:
         branches:
             - 'main'

--- a/src/Goodby/CSV/Export/Standard/Collection/CallbackCollection.php
+++ b/src/Goodby/CSV/Export/Standard/Collection/CallbackCollection.php
@@ -4,6 +4,7 @@ namespace Goodby\CSV\Export\Standard\Collection;
 
 use Iterator;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 
 class CallbackCollection implements Iterator
 {
@@ -36,6 +37,7 @@ class CallbackCollection implements Iterator
      * @link http://php.net/manual/en/iterator.current.php
      * @return mixed Can return any type.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return call_user_func($this->callable, $this->data->current());
@@ -47,6 +49,7 @@ class CallbackCollection implements Iterator
      * @link http://php.net/manual/en/iterator.next.php
      * @return void Any returned value is ignored.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->data->next();
@@ -58,6 +61,7 @@ class CallbackCollection implements Iterator
      * @link http://php.net/manual/en/iterator.key.php
      * @return mixed scalar on success, or null on failure.
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->data->key();
@@ -70,6 +74,7 @@ class CallbackCollection implements Iterator
      * @return boolean The return value will be casted to boolean and then evaluated.
      * Returns true on success or false on failure.
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->data->valid();
@@ -81,6 +86,7 @@ class CallbackCollection implements Iterator
      * @link http://php.net/manual/en/iterator.rewind.php
      * @return void Any returned value is ignored.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->data->rewind();

--- a/src/Goodby/CSV/Export/Standard/Collection/PdoCollection.php
+++ b/src/Goodby/CSV/Export/Standard/Collection/PdoCollection.php
@@ -4,6 +4,7 @@ namespace Goodby\CSV\Export\Standard\Collection;
 
 use Iterator;
 use PDO;
+use ReturnTypeWillChange;
 
 class PdoCollection implements Iterator
 {
@@ -29,6 +30,7 @@ class PdoCollection implements Iterator
      * @link http://php.net/manual/en/iterator.current.php
      * @return mixed Can return any type.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->stmt->fetch(PDO::FETCH_ASSOC);
@@ -40,6 +42,7 @@ class PdoCollection implements Iterator
      * @link http://php.net/manual/en/iterator.next.php
      * @return void Any returned value is ignored.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->current++;
@@ -51,6 +54,7 @@ class PdoCollection implements Iterator
      * @link http://php.net/manual/en/iterator.key.php
      * @return mixed scalar on success, or null on failure.
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         $this->current;
@@ -63,6 +67,7 @@ class PdoCollection implements Iterator
      * @return boolean The return value will be casted to boolean and then evaluated.
      * Returns true on success or false on failure.
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return ($this->rowCount > $this->current);
@@ -74,6 +79,7 @@ class PdoCollection implements Iterator
      * @link http://php.net/manual/en/iterator.rewind.php
      * @return void Any returned value is ignored.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->stmt->execute();

--- a/src/Goodby/CSV/Export/Standard/CsvFileObject.php
+++ b/src/Goodby/CSV/Export/Standard/CsvFileObject.php
@@ -2,6 +2,7 @@
 
 namespace Goodby\CSV\Export\Standard;
 
+use ReturnTypeWillChange;
 use SplFileObject;
 
 class CsvFileObject extends SplFileObject

--- a/src/Goodby/CSV/Export/Standard/Exporter.php
+++ b/src/Goodby/CSV/Export/Standard/Exporter.php
@@ -61,7 +61,7 @@ class Exporter implements ExporterInterface
         try {
             $csv = new CsvFileObject($filename, $fileMode);
         } catch ( \Exception $e ) {
-            throw new IOException($e->getMessage(), null, $e);
+            throw new IOException($e->getMessage(), 0, $e);
         }
 
         $csv->setNewline($newline);

--- a/src/Goodby/CSV/Export/Tests/Standard/Unit/Collection/SampleAggIterator.php
+++ b/src/Goodby/CSV/Export/Tests/Standard/Unit/Collection/SampleAggIterator.php
@@ -3,8 +3,10 @@
 namespace Goodby\CSV\Export\Tests\Standard\Unit\Collection;
 
 use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
 
-class SampleAggIterator implements \IteratorAggregate
+class SampleAggIterator implements IteratorAggregate
 {
     protected $data;
 
@@ -13,7 +15,7 @@ class SampleAggIterator implements \IteratorAggregate
         $this->data = $data;
     }
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->data);
     }

--- a/src/Goodby/CSV/Import/Standard/Lexer.php
+++ b/src/Goodby/CSV/Import/Standard/Lexer.php
@@ -33,7 +33,7 @@ class Lexer implements LexerInterface
      */
     public function parse($filename, InterpreterInterface $interpreter)
     {
-        ini_set('auto_detect_line_endings', true); // For mac's office excel csv
+        @ini_set('auto_detect_line_endings', true); // For mac's office excel csv
 
         $delimiter      = $this->config->getDelimiter();
         $enclosure      = $this->config->getEnclosure();
@@ -57,7 +57,7 @@ class Lexer implements LexerInterface
         setlocale(LC_ALL, 'en_US.UTF-8');
 
         foreach ( $csv as $lineNumber => $line ) {
-            if ($ignoreHeader && $lineNumber == 0 || ((is_array($line) || $line instanceof \Countable ? count($line) : 0) === 1 && trim($line[0]) === '')) {
+            if ($ignoreHeader && $lineNumber == 0 || ((is_array($line) || $line instanceof \Countable ? count($line) : 0) === 1 && trim((string) $line[0]) === '')) {
                 continue;
             }
             $interpreter->interpret($line);

--- a/src/Goodby/CSV/Import/Standard/StreamFilter/ConvertMbstringEncoding.php
+++ b/src/Goodby/CSV/Import/Standard/StreamFilter/ConvertMbstringEncoding.php
@@ -3,6 +3,7 @@
 namespace Goodby\CSV\Import\Standard\StreamFilter;
 
 use php_user_filter;
+use ReturnTypeWillChange;
 use RuntimeException;
 
 class ConvertMbstringEncoding extends php_user_filter
@@ -31,6 +32,7 @@ class ConvertMbstringEncoding extends php_user_filter
      * Return filter name
      * @return string
      */
+    #[ReturnTypeWillChange]
     public static function getFilterName()
     {
         return self::FILTER_NAMESPACE.'*';
@@ -40,6 +42,7 @@ class ConvertMbstringEncoding extends php_user_filter
      * Register this class as a stream filter
      * @throws \RuntimeException
      */
+    #[ReturnTypeWillChange]
     public static function register()
     {
         if ( self::$hasBeenRegistered === true ) {
@@ -60,6 +63,7 @@ class ConvertMbstringEncoding extends php_user_filter
      * @param string $toCharset
      * @return string
      */
+    #[ReturnTypeWillChange]
     public static function getFilterURL($filename, $fromCharset, $toCharset = null)
     {
         if ( $toCharset === null ) {
@@ -72,6 +76,7 @@ class ConvertMbstringEncoding extends php_user_filter
     /**
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function onCreate()
     {
         if ( strpos($this->filtername, self::FILTER_NAMESPACE) !== 0 ) {
@@ -97,6 +102,7 @@ class ConvertMbstringEncoding extends php_user_filter
      * @param $closing
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function filter($in, $out, &$consumed, $closing)
     {
         while ( $bucket = stream_bucket_make_writeable($in) ) {


### PR DESCRIPTION
This PR fixes some more deprecations reported by PHP 8.1:
- [x] `#[ReturnTypeWillChange]` should be imported or used as `#[\ReturnTypeWillChange]` (root namespace), also added it in more places now
- [x] Passing `null` as `$code` in exceptions is deprecated - replaced with `0`
- [x] `auto_detect_line_endings` ini setting is deprecated as of 8.1 - suppressing it with `@` for now
- [x] Passing `null` to `trim()` is deprecated - casting to `string` first as that's how it behaved on older PHP versions.

Further steps to consider:
- Add native type hints everywhere, especially where extending core classes and interfaces, like `Iterator` and `php_user_filter` - we need to make sure PHP 7.2 contravariance will allow that or bump minimal requirement to PHP 7.4.
- Revise "magic" casting and make use of `strict_types=1` - add some static analysis to make sure we don't pass invalid types